### PR TITLE
Adjustable scaling, and experimental logarithmic scaling.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,2 @@
 rm build/libs/cobblemounts-*.jar
 ./gradlew build
-cp build/libs/cobblemounts-*.jar /home/gavin/.var/app/org.prismlauncher.PrismLauncher/data/PrismLauncher/instances/1.20.1/.minecraft/mods/

--- a/src/main/java/net/ioixd/Config.java
+++ b/src/main/java/net/ioixd/Config.java
@@ -14,10 +14,23 @@ import net.minecraft.network.PacketByteBuf;
 
 public class Config implements FabricPacket {
 
-    public boolean cappedSpeed = true;
-    public double speedCap = 0.15;
-    public double flyingSpeedCap = 0.15;
-    public double legendaryModifier = 0.05;
+    public boolean groundCappedSpeed = true;
+    public boolean groundUseLogScaling = true;
+    public double groundSpeedScalar = 150.0d;
+    public double groundSpeedCap = 3.0d;
+
+    public boolean flightCappedSpeed = true;
+    public boolean flightUseLogScaling = true;
+    public double flightSpeedScalar = 300.0d;
+    public double flightSpeedCap = 2.0d;
+
+    public boolean swimCappedSpeed = true;
+    public boolean swimUseLogScaling = true;
+    public double swimSpeedScalar = 75.0d;
+    public double swimSpeedCap = 4.0d;
+
+    public double legendaryModifier = 0.5d;
+    public boolean legendaryModifierCapBreak = true;
 
     public boolean allowFlying = true;
     public boolean allowSwimming = true;
@@ -29,10 +42,25 @@ public class Config implements FabricPacket {
 
     @Override
     public void write(PacketByteBuf p) {
-        p.writeBoolean(cappedSpeed);
-        p.writeDouble(speedCap);
+
+        p.writeBoolean(groundCappedSpeed);
+        p.writeBoolean(groundUseLogScaling);
+        p.writeDouble(groundSpeedScalar);
+        p.writeDouble(groundSpeedCap);
+
+        p.writeBoolean(flightCappedSpeed);
+        p.writeBoolean(flightUseLogScaling);
+        p.writeDouble(flightSpeedScalar);
+        p.writeDouble(flightSpeedCap);
+
+        p.writeBoolean(swimCappedSpeed);
+        p.writeBoolean(swimUseLogScaling);
+        p.writeDouble(swimSpeedScalar);
+        p.writeDouble(swimSpeedCap);
+
         p.writeDouble(legendaryModifier);
-        p.writeDouble(flyingSpeedCap);
+        p.writeBoolean(legendaryModifierCapBreak);
+        
         p.writeBoolean(allowFlying);
         p.writeBoolean(allowSwimming);
         p.writeEnumConstant(listUse);
@@ -109,12 +137,27 @@ public class Config implements FabricPacket {
             throw new RuntimeException(ex);
         }
 
-        this.cappedSpeed = toml.getBoolean("cappedSpeed", true);
-        this.speedCap = toml.getDouble("speedCap", 0.15);
-        this.legendaryModifier = toml.getDouble("legenedaryModifier", 0.05);
-        this.flyingSpeedCap = toml.getDouble("flyingSpeedCap", 0.15);
-        this.allowFlying = toml.getBoolean("allowFlying", true);
-        this.allowSwimming = toml.getBoolean("allowSwimming", true);
+        this.groundCappedSpeed = toml.getBoolean("groundCappedSpeed", true);
+        this.groundUseLogScaling = toml.getBoolean("groundUseLogScaling", false);
+        this.groundSpeedScalar = toml.getDouble("groundSpeedScalar", 150.0d);
+        this.groundSpeedCap = toml.getDouble("groundSpeedCap", 3.0d);
+
+        this.flightCappedSpeed = toml.getBoolean("flightCappedSpeed", true);
+        this.flightUseLogScaling = toml.getBoolean("flightUseLogScaling", true);
+        this.flightSpeedScalar = toml.getDouble("flightSpeedScalar", 300.0d);
+        this.flightSpeedCap = toml.getDouble("flightSpeedCap", 2.0d);
+
+        this.swimCappedSpeed = toml.getBoolean("swimCappedSpeed", true);
+        this.swimUseLogScaling = toml.getBoolean("swimUseLogScaling", true);
+        this.swimSpeedScalar = toml.getDouble("swimSpeedScalar", 75.0d);
+        this.swimSpeedCap = toml.getDouble("swimSpeedCap", 4.0d);
+
+        this.legendaryModifier = toml.getDouble("legenedaryModifier", 0.5d);
+        this.legendaryModifierCapBreak = toml.getBoolean("legenedaryModifierCapBreak", true);
+
+        this.allowFlying = true;
+        this.allowSwimming = true;
+
         String listUse = toml.getString("listUse", "").toLowerCase();
         switch (listUse) {
             case "blacklist":
@@ -137,12 +180,28 @@ public class Config implements FabricPacket {
 
     public static Config read(PacketByteBuf p) {
         var config = new Config();
-        config.cappedSpeed = p.readBoolean();
-        config.speedCap = p.readDouble();
-        config.legendaryModifier = p.readDouble();
-        config.flyingSpeedCap = p.readDouble();
+        
+        config.groundCappedSpeed = p.readBoolean();
+        config.groundUseLogScaling = p.readBoolean();
+        config.groundSpeedScalar = p.readDouble();
+        config.groundSpeedCap = p.readDouble();
+
+        config.flightCappedSpeed = p.readBoolean();
+        config.flightUseLogScaling = p.readBoolean();
+        config.flightSpeedScalar = p.readDouble();
+        config.flightSpeedCap = p.readDouble();
+
+        config.swimCappedSpeed = p.readBoolean();
+        config.swimUseLogScaling = p.readBoolean();
+        config.swimSpeedScalar = p.readDouble();
+        config.swimSpeedCap = p.readDouble();
+
+        config.swimSpeedCap = p.readDouble();
+        config.legendaryModifierCapBreak = p.readBoolean();
+        
         config.allowFlying = p.readBoolean();
         config.allowSwimming = p.readBoolean();
+
         config.listUse = p.readEnumConstant(ListUse.class);
         int s = p.readInt();
         config.list = new ArrayList<>(s);

--- a/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
@@ -54,6 +54,7 @@ public abstract class PokemonMovementHandler extends LivingEntity {
 
         float speedModifier = pokemonData.isLegendary() ? 0.0f
                 : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
+        float speedScaling = (float) CobblemountsClient.SYNCED_CONFIG.speedScaling;
         AtomicBoolean isFlying = new AtomicBoolean(false);
         Vec3d moveXZ = movement;// movement.rotateY((float) Math.toRadians(-player.getYaw()));
         Vec3d forward = player.getRotationVector().normalize().multiply(movement.z);
@@ -102,7 +103,7 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                     ;
                     if (condition) {
                         if (flyMove.z != 0.0) {
-                            double flyingSpeed = ((pokemonData.getSpeed() / 64.0f) + speedModifier) * 8.0;
+                            double flyingSpeed = ((pokemonData.getSpeed() / 64.0f) + speedModifier) * speedScaling;
                             if (CobblemountsClient.SYNCED_CONFIG.cappedSpeed) {
                                 if (flyingSpeed >= CobblemountsClient.SYNCED_CONFIG.flyingSpeedCap) {
                                     flyingSpeed = CobblemountsClient.SYNCED_CONFIG.flyingSpeedCap;

--- a/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
@@ -102,16 +102,16 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                     if (condition) {
                         // Let the spaghetti begin. Now may be time to say that I have NEVER coded Java before :s
                         // First, decide between swimming or flying scalars
+                        float speedScalar = (float) CobblemountsClient.SYNCED_CONFIG.swimSpeedScalar;
+                        float speedCap = (float) CobblemountsClient.SYNCED_CONFIG.swimSpeedCap;
+                        boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.swimCappedSpeed;
+                        boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.swimUseLogScaling;
+                        
                         if (flying) {
-                            float speedScalar = CobblemountsClient.SYNCED_CONFIG.flightSpeedScalar;
-                            float speedCap = CobblemountsClient.SYNCED_CONFIG.flightSpeedCap;
-                            boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.flightCappedSpeed;
-                            boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.flightUseLogScaling;
-                        } else {
-                            float speedScalar = CobblemountsClient.SYNCED_CONFIG.swimSpeedScalar;
-                            float speedCap = CobblemountsClient.SYNCED_CONFIG.swimSpeedCap;
-                            boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.swimCappedSpeed;
-                            boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.swimUseLogScaling;
+                            speedScalar = (float) CobblemountsClient.SYNCED_CONFIG.flightSpeedScalar;
+                            speedCap = (float) CobblemountsClient.SYNCED_CONFIG.flightSpeedCap;
+                            isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.flightCappedSpeed;
+                            useLogScaling = CobblemountsClient.SYNCED_CONFIG.flightUseLogScaling;
                         }
                         // Then, do some additional checks for legendaries
                         float legendaryModifier = pokemonData.isLegendary() ? 0.0f
@@ -121,11 +121,12 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                         // Fun fact, in a previous itteration, I repeated this code twice with a check to see if we
                         // were opperating in swim mode or flight mode. I need coffee.
                         // elifelifelifelifelifelifelifelifelifelifelif...
+                        float flyingSpeed = 0.0f;
                         if (flyMove.z != 0.0) {
                             // Step 1 : check if using log or lin scaling
                             if (!useLogScaling) {
                                 // Step 2 : compute the base flight speed
-                                double flyingSpeed = ((pokemonData.getSpeed() / 256.0f) * (speedScalar / 2.0f));
+                                flyingSpeed = ((pokemonData.getSpeed() / 256.0f) * (speedScalar / 2.0f));
                                 // Step 3 : check if the cobblemon is legendary
                                  if (isLegendary) {
                                     // Step 3.1 : check if speed cap is applied
@@ -158,7 +159,7 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                             } else {
                                 // We're not done yet ! We still need to do the SAME EXACT THING but for LOGARITHMIC SCALING !!!!!!
                                 // Step 2
-                                double flyingSpeed = (log(pokemonData.getSpeed() + speedScalar) / speedScalar);
+                                flyingSpeed = 2.5f * (float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar);
                                 // Step 3
                                 if (isLegendary) {
                                     // Step 3.1

--- a/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
@@ -52,9 +52,7 @@ public abstract class PokemonMovementHandler extends LivingEntity {
         Block water = pokemon.getBlockStateAtPos().getBlock();
         boolean inLiquid = water instanceof FluidBlock;
 
-        float speedModifier = pokemonData.isLegendary() ? 0.0f
-                : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
-        float speedScaling = (float) CobblemountsClient.SYNCED_CONFIG.speedScaling;
+
         AtomicBoolean isFlying = new AtomicBoolean(false);
         Vec3d moveXZ = movement;// movement.rotateY((float) Math.toRadians(-player.getYaw()));
         Vec3d forward = player.getRotationVector().normalize().multiply(movement.z);
@@ -100,14 +98,96 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                             flying = false;
                             break;
                     }
-                    ;
+
                     if (condition) {
+                        // Let the spaghetti begin. Now may be time to say that I have NEVER coded Java before :s
+                        // First, decide between swimming or flying scalars
+                        if (flying) {
+                            float speedScalar = CobblemountsClient.SYNCED_CONFIG.flightSpeedScalar;
+                            float speedCap = CobblemountsClient.SYNCED_CONFIG.flightSpeedCap;
+                            boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.flightCappedSpeed;
+                            boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.flightUseLogScaling;
+                        } else {
+                            float speedScalar = CobblemountsClient.SYNCED_CONFIG.swimSpeedScalar;
+                            float speedCap = CobblemountsClient.SYNCED_CONFIG.swimSpeedCap;
+                            boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.swimCappedSpeed;
+                            boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.swimUseLogScaling;
+                        }
+                        // Then, do some additional checks for legendaries
+                        float legendaryModifier = pokemonData.isLegendary() ? 0.0f
+                            : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
+                        boolean isLegendary = pokemonData.isLegendary();
+                 
+                        // Fun fact, in a previous itteration, I repeated this code twice with a check to see if we
+                        // were opperating in swim mode or flight mode. I need coffee.
+                        // elifelifelifelifelifelifelifelifelifelifelif...
                         if (flyMove.z != 0.0) {
-                            double flyingSpeed = ((pokemonData.getSpeed() / 64.0f) + speedModifier) * speedScaling;
-                            if (CobblemountsClient.SYNCED_CONFIG.cappedSpeed) {
-                                if (flyingSpeed >= CobblemountsClient.SYNCED_CONFIG.flyingSpeedCap) {
-                                    flyingSpeed = CobblemountsClient.SYNCED_CONFIG.flyingSpeedCap;
+                            // Step 1 : check if using log or lin scaling
+                            if (!useLogScaling) {
+                                // Step 2 : compute the base flight speed
+                                double flyingSpeed = ((pokemonData.getSpeed() / 256.0f) * (speedScalar / 2.0f));
+                                // Step 3 : check if the cobblemon is legendary
+                                 if (isLegendary) {
+                                    // Step 3.1 : check if speed cap is applied
+                                    if (isSpeedCapped) {
+                                        // Step 3.2 : check if speed cap breaking is allowed
+                                        if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
+                                            // Step 3.3 : compute final speed based on broken cap
+                                            if (flyingSpeed >= speedCap) {
+                                                flyingSpeed = (speedCap + ((legendaryModifier * speedScalar) / 2.0f));
+                                            } else {
+                                                flyingSpeed = (flyingSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                                            }
+                                        } else {
+                                            flyingSpeed = (flyingSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                                            if (flyingSpeed >= speedCap) {
+                                                flyingSpeed = speedCap;
+                                            }
+                                        }
+                                    } else {
+                                        flyingSpeed = (flyingSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                                    }
+                                } else {
+                                    // If the cobblemon isn't legendary, at least there's no cap-breaking shenanigans.
+                                    if (isSpeedCapped) {
+                                        if (flyingSpeed >= speedCap) {
+                                            flyingSpeed = speedCap;
+                                        }
+                                    }
                                 }
+                            } else {
+                                // We're not done yet ! We still need to do the SAME EXACT THING but for LOGARITHMIC SCALING !!!!!!
+                                // Step 2
+                                double flyingSpeed = (log(pokemonData.getSpeed() + speedScalar) / speedScalar);
+                                // Step 3
+                                if (isLegendary) {
+                                    // Step 3.1
+                                    if (isSpeedCapped) {
+                                        // Step 3.2
+                                        if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
+                                            // Step 3.3
+                                            if (flyingSpeed >= speedCap) {
+                                                flyingSpeed = (speedCap + legendaryModifier);
+                                            } else {
+                                                flyingSpeed = (flyingSpeed + legendaryModifier);
+                                            }
+                                        } else {
+                                            flyingSpeed = (flyingSpeed + legendaryModifier);
+                                            if (flyingSpeed >= speedCap) {
+                                                flyingSpeed = speedCap;
+                                            }
+                                        }
+                                    } else {
+                                        flyingSpeed = (flyingSpeed + legendaryModifier);
+                                    }
+                                } else {
+                                    if (isSpeedCapped) {
+                                        if (flyingSpeed >= speedCap) {
+                                           flyingSpeed = speedCap;
+                                        }
+                                    }
+                                }
+
                             }
                             pokemon.move(MovementType.SELF, flyMove.multiply(flyingSpeed));
                             isFlying.set(true);
@@ -120,7 +200,7 @@ public abstract class PokemonMovementHandler extends LivingEntity {
                         pokemon.setPose(EntityPose.STANDING);
                     }
                     break;
-            }
+            }        
         });
         if (!isFlying.get()) {
             if (!(player instanceof ServerPlayerEntity) && MinecraftClient.getInstance().options.jumpKey.isPressed()

--- a/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
@@ -69,7 +69,7 @@ public class PokemonUpdateTick {
                         }
                     }
                 } else {
-                    movementSpeed = (player.getMovementSpeed() * ((float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar))) / 5.0f;
+                    movementSpeed = (player.getMovementSpeed() * (2.5f*(float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar))) / 5.0f;
                     if (isLegendary) {
                         if (isSpeedCapped) {
                             if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {

--- a/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
@@ -30,11 +30,73 @@ public class PokemonUpdateTick {
             Pokemon pokemonData = pokemonEntity.getPokemon();
             Entity firstPassenger = pokemonEntity.getFirstPassenger();
             if (firstPassenger instanceof PlayerEntity player) {
+                
                 // Make the Pokemon's position match the player's and set their position
                 // accordingly.
-                float speedModifier = pokemonData.isLegendary() ? 0.0f
-                        : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
-                float movementSpeed = player.getMovementSpeed() * (pokemonData.getSpeed() / 12.0f) + speedModifier;
+                float legendaryModifier = pokemonData.isLegendary() ? 0.0f
+                    : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
+                boolean isLegendary = pokemonData.isLegendary();
+                //float movementSpeed = player.getMovementSpeed() * (pokemonData.getSpeed() / 12.0f) + speedModifier;
+                float speedScalar = CobblemountsClient.SYNCED_CONFIG.speedScalar;
+                float speedCap = CobblemountsClient.SYNCED_CONFIG.speedCap;
+                boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.cappedSpeed;
+                boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.useLogScaling;
+                
+                if (!useLogScaling) {
+                    float movementSpeed = player.getMovementSpeed() * ((pokemonData.getSpeed() / 12.0f) * (speedScalar / 2.0f));
+                    if (isLegendary) {
+                        if (isSpeedCapped) {
+                            if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
+                                if (movementSpeed >= speedCap) {
+                                    movementSpeed = (speedCap + ((legendaryModifier * speedScalar) / 2.0f));
+                                } else {
+                                    movementSpeed = (movementSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                                }
+                            } else {
+                                movementSpeed = (movementSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                                if (movementSpeed >= speedCap) {
+                                    movementSpeed = speedCap;
+                                }
+                            }
+                        } else {
+                            movementSpeed = (movementSpeed + ((legendaryModifier * speedScalar) / 2.0f));
+                        }
+                    } else {
+                        if (isSpeedCapped) {
+                            if (movementSpeed >= speedCap) {
+                                movementSpeed = speedCap;
+                            }
+                        }
+                    }
+                } else {
+                    float movementSpeed = player.getMovementSpeed() * ((log(pokemonData.getSpeed() + speedScalar) / speedScalar) / 5.0f);
+                    if (isLegendary) {
+                        if (isSpeedCapped) {
+                            if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
+                                if (movementSpeed >= speedCap) {
+                                    movementSpeed = (speedCap + legendaryModifier);
+                                } else {
+                                    movementSpeed = (movementSpeed + legendaryModifier);
+                                }
+                            } else {
+                                movementSpeed = (movementSpeed + legendaryModifier);
+                                if (movementSpeed >= speedCap) {
+                                    movementSpeed = speedCap;
+                                }
+                            }
+                        } else {
+                            movementSpeed = (movementSpeed + legendaryModifier);
+                        }
+                    } else {
+                        if (isSpeedCapped) {
+                            if (movementSpeed >= speedCap) {
+                                movementSpeed = speedCap;
+                            }
+                        }
+                    }
+
+                }
+                
                 if (CobblemountsClient.SYNCED_CONFIG.cappedSpeed) {
                     if (movementSpeed >= CobblemountsClient.SYNCED_CONFIG.speedCap) {
                         movementSpeed = (float) CobblemountsClient.SYNCED_CONFIG.speedCap;

--- a/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
@@ -69,7 +69,7 @@ public class PokemonUpdateTick {
                         }
                     }
                 } else {
-                    movementSpeed = (player.getMovementSpeed() * (2.5f*(float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar))) / 5.0f;
+                    movementSpeed = (player.getMovementSpeed() * 10.0f * (2.5f*(float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar)));
                     if (isLegendary) {
                         if (isSpeedCapped) {
                             if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {

--- a/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
@@ -37,13 +37,13 @@ public class PokemonUpdateTick {
                     : (float) CobblemountsClient.SYNCED_CONFIG.legendaryModifier;
                 boolean isLegendary = pokemonData.isLegendary();
                 //float movementSpeed = player.getMovementSpeed() * (pokemonData.getSpeed() / 12.0f) + speedModifier;
-                float speedScalar = CobblemountsClient.SYNCED_CONFIG.speedScalar;
-                float speedCap = CobblemountsClient.SYNCED_CONFIG.speedCap;
-                boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.cappedSpeed;
-                boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.useLogScaling;
-                
+                float speedScalar = (float) CobblemountsClient.SYNCED_CONFIG.groundSpeedScalar;
+                float speedCap = (float) CobblemountsClient.SYNCED_CONFIG.groundSpeedCap;
+                boolean isSpeedCapped = CobblemountsClient.SYNCED_CONFIG.groundCappedSpeed;
+                boolean useLogScaling = CobblemountsClient.SYNCED_CONFIG.groundUseLogScaling;
+                float movementSpeed = 0.0f;
                 if (!useLogScaling) {
-                    float movementSpeed = player.getMovementSpeed() * ((pokemonData.getSpeed() / 12.0f) * (speedScalar / 2.0f));
+                    movementSpeed = player.getMovementSpeed() * ((pokemonData.getSpeed() / 12.0f) * (speedScalar / 2.0f));
                     if (isLegendary) {
                         if (isSpeedCapped) {
                             if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
@@ -69,7 +69,7 @@ public class PokemonUpdateTick {
                         }
                     }
                 } else {
-                    float movementSpeed = player.getMovementSpeed() * ((log(pokemonData.getSpeed() + speedScalar) / speedScalar) / 5.0f);
+                    movementSpeed = (player.getMovementSpeed() * ((float)Math.log((pokemonData.getSpeed() + speedScalar) / speedScalar))) / 5.0f;
                     if (isLegendary) {
                         if (isSpeedCapped) {
                             if (CobblemountsClient.SYNCED_CONFIG.legendaryModifierCapBreak) {
@@ -95,12 +95,6 @@ public class PokemonUpdateTick {
                         }
                     }
 
-                }
-                
-                if (CobblemountsClient.SYNCED_CONFIG.cappedSpeed) {
-                    if (movementSpeed >= CobblemountsClient.SYNCED_CONFIG.speedCap) {
-                        movementSpeed = (float) CobblemountsClient.SYNCED_CONFIG.speedCap;
-                    }
                 }
                 pokemonEntity.limbAnimator.setSpeed(pokemonEntity.getMovementSpeed() / 1.3f);
 

--- a/src/main/resources/cobblemounts.toml
+++ b/src/main/resources/cobblemounts.toml
@@ -1,9 +1,40 @@
+# useLogScaling = false : 
+# movement speed = ((pkmn speed / 256) * (scalar / 2)) + ((legendaryModifier * scalar) / 2)
+# useLogScaling = true :
+# movement speed = log((pkmn speed + scalar) / scalar) + legendaryModifier
+# For LINEAR scaling, a HIGHER scalar means MORE speed
+# LINEAR scaling means that every point of speed matters as much as every other
+# For LOGARITHMIC scaling, a HIGHER scalar means LESS speed
+# LOGARITHMIC scaling means that movement speed grows faster with low speed stats but slower with more speed stats
+# Basically : 
+# Linear : low investment, low rewards. medium investment, medium rewards. high investment, high reward.
+# Logarithmic : low investment, low-medium reward. medium investment, medium-high reward. high investment, medium-high rewards.
+# If unsure... leave those settings default. If you want to tinker with balance... here's a link to the graph compairing
+# the two modes of scaling for my math nerds : https://www.desmos.com/calculator/ccxdf7ll24
+
 cappedSpeed = true
-speedCap = 0.4
-flyingSpeedCap = 3.0     # Also applies to swimming Pokemon.
-legendaryModifier = 0.05 # Legendaries get an additive boost to their speed (this is capped by the speed cap)
+useLogScaling = false
+speedScalar = 4.0
+speedCap = 3.0
+
+flightCappedSpeed = true
+flightUseLogScaling = true
+flightSpeedScalar = 50.0
+flightSpeedCap = 2.0 
+
+swimCappedSpeed = true
+swimUseLogScaling = true
+swimSpeedScalar = 5.5
+swimSpeedCap = 4.0
+
+# Legendaries get a speed boost accounted for in the formula.
+# You may chose to let it bypass the speed caps.
+legendaryModifier = 0.5
+legendaryModifierCapBreak = true
+#
 allowFlying = true
 allowSwimming = true
+
 list = []                # Which Pokemon you can or can't mount.
 alsoFlying = []          # Which Pokemons can fly, ignoring its types
 listUse = ""             # Set to "blacklist" or "whitelist" to control the behavior of the below list. If it is an invalid option or blank, the option isn't used.

--- a/src/main/resources/cobblemounts.toml
+++ b/src/main/resources/cobblemounts.toml
@@ -18,7 +18,7 @@
 # Ground speed 3 @ 350 spd
 groundCappedSpeed = true    # Linear default : true
 groundUseLogScaling = true  # Linear default : false
-groundSpeedScalar = 150     # Linear default : 170
+groundSpeedScalar = 150.0   # Linear default : 170
 groundSpeedCap = 3.0        # Linear default : 0.4
 
 # Flight is extremely versatile, so its capped at 2. Also, speed 1 is 

--- a/src/main/resources/cobblemounts.toml
+++ b/src/main/resources/cobblemounts.toml
@@ -1,7 +1,19 @@
 # useLogScaling = false : 
 # movement speed = ((pkmn speed / 256) * (scalar / 2)) + ((legendaryModifier * scalar) / 2)
 # useLogScaling = true :
-# movement speed = log((pkmn speed + scalar) / scalar) + legendaryModifier
+# movement speed = 2.5log((pkmn speed + scalar) / scalar) + legendaryModifier
+# For LINEAR scaling, a HIGHER scalar means MORE speed
+# LINEAR scaling means that every point of speed matters as much as every other
+# For LOGARITHMIC scaling, a HIGHER scalar means LESS speed
+# LOGARITHMIC scaling means that movement speed grows faster with low speed stats but slower with more speed stats
+# Basically : 
+# Linear : low investment, low rewards. medium investment, medium rewards. high investment, high reward.
+# Logarithmic : low investment, low-medium reward. medium investment, medium-high reward. high investment, medium-high rewards.
+# If unsure... leave those settings default. If you want to tinker with balance... here's a link to the graph compairing
+# the two modes of scaling for my math nerds : # useLogScaling = false : 
+# movement speed = ((pkmn speed / 256) * (scalar / 2)) + ((legendaryModifier * scalar) / 2)
+# useLogScaling = true :
+# movement speed = 2.5log((pkmn speed + scalar) / scalar) + legendaryModifier
 # For LINEAR scaling, a HIGHER scalar means MORE speed
 # LINEAR scaling means that every point of speed matters as much as every other
 # For LOGARITHMIC scaling, a HIGHER scalar means LESS speed
@@ -12,19 +24,74 @@
 # If unsure... leave those settings default. If you want to tinker with balance... here's a link to the graph compairing
 # the two modes of scaling for my math nerds : https://www.desmos.com/calculator/ccxdf7ll24
 
-cappedSpeed = true
-useLogScaling = false
-speedScalar = 4.0
-speedCap = 3.0
+# Ground speed isn't as versatile as flight, so it scales harder.
+# Ground speed 1 @ 75 spd
+# Ground speed 2 @ 180 spd
+# Ground speed 3 @ 350 spd
+groundCappedSpeed = true
+groundUseLogScaling = true
+groundSpeedScalar = 150
+groundSpeedCap = 3
 
+# Flight is extremely versatile, so its capped at 2. Also, speed 1 is 
+# available relatively early for exploration, but speed 2 will require
+# a time investment in a speed 350 bird.
+# Flight speed 1 @ 150 spd
+# Flight speed 2 @ 350 spd
 flightCappedSpeed = true
 flightUseLogScaling = true
-flightSpeedScalar = 50.0
-flightSpeedCap = 2.0 
+flightSpeedScalar = 300.0
+flightSpeedCap = 2.0
 
-swimCappedSpeed = true
+# Simming is the most niche ability, so it's uncapped and scales the hardest.
+# Swim speed 1 @ 40 spd
+# Swim speed 2 @ 90 spd
+# Swim speed 3 @ 170 spd 
+# Swim speed 4 @ 300 spd 
+swimCappedSpeed = false
 swimUseLogScaling = true
-swimSpeedScalar = 5.5
+swimSpeedScalar = 75.0
+swimSpeedCap = 4.0
+
+# Legendaries get a speed boost accounted for in the formula.
+# You may chose to let it bypass the speed caps.
+legendaryModifier = 0.5
+legendaryModifierCapBreak = true
+#
+allowFlying = true
+allowSwimming = true
+
+list = []                # Which Pokemon you can or can't mount.
+alsoFlying = []          # Which Pokemons can fly, ignoring its types
+listUse = ""             # Set to "blacklist" or "whitelist" to control the behavior of the below list. If it is an invalid option or blank, the option isn't used.
+
+# Ground speed isn't as versatile as flight, so it scales harder.
+# Ground speed 1 @ 75 spd
+# Ground speed 2 @ 180 spd
+# Ground speed 3 @ 350 spd
+groundCappedSpeed = true
+groundUseLogScaling = true
+groundSpeedScalar = 150
+groundSpeedCap = 3
+
+# Flight is extremely versatile, so its capped at 2. Also, speed 1 is 
+# available relatively early for exploration, but speed 2 will require
+# a time investment in a speed 350 bird.
+# Flight speed 1 @ 150 spd
+# Flight speed 2 @ 350 spd
+flightCappedSpeed = true
+flightUseLogScaling = true
+flightSpeedScalar = 300.0
+flightSpeedCap = 2.0
+
+# Simming is the most niche ability, so it's uncapped and scales the hardest.
+# Swim speed 1 @ 40 spd
+# Swim speed 2 @ 90 spd
+# Swim speed 3 @ 170 spd 
+# Swim speed 4 @ 300 spd 
+swimCappedSpeed = false
+swimUseLogScaling = true
+swimSpeedScalar = 75.0
 swimSpeedCap = 4.0
 
 # Legendaries get a speed boost accounted for in the formula.

--- a/src/main/resources/cobblemounts.toml
+++ b/src/main/resources/cobblemounts.toml
@@ -10,95 +10,43 @@
 # Linear : low investment, low rewards. medium investment, medium rewards. high investment, high reward.
 # Logarithmic : low investment, low-medium reward. medium investment, medium-high reward. high investment, medium-high rewards.
 # If unsure... leave those settings default. If you want to tinker with balance... here's a link to the graph compairing
-# the two modes of scaling for my math nerds : # useLogScaling = false : 
-# movement speed = ((pkmn speed / 256) * (scalar / 2)) + ((legendaryModifier * scalar) / 2)
-# useLogScaling = true :
-# movement speed = 2.5log((pkmn speed + scalar) / scalar) + legendaryModifier
-# For LINEAR scaling, a HIGHER scalar means MORE speed
-# LINEAR scaling means that every point of speed matters as much as every other
-# For LOGARITHMIC scaling, a HIGHER scalar means LESS speed
-# LOGARITHMIC scaling means that movement speed grows faster with low speed stats but slower with more speed stats
-# Basically : 
-# Linear : low investment, low rewards. medium investment, medium rewards. high investment, high reward.
-# Logarithmic : low investment, low-medium reward. medium investment, medium-high reward. high investment, medium-high rewards.
-# If unsure... leave those settings default. If you want to tinker with balance... here's a link to the graph compairing
 # the two modes of scaling for my math nerds : https://www.desmos.com/calculator/ccxdf7ll24
 
 # Ground speed isn't as versatile as flight, so it scales harder.
 # Ground speed 1 @ 75 spd
 # Ground speed 2 @ 180 spd
 # Ground speed 3 @ 350 spd
-groundCappedSpeed = true
-groundUseLogScaling = true
-groundSpeedScalar = 150
-groundSpeedCap = 3
+groundCappedSpeed = true    # Linear default : true
+groundUseLogScaling = true  # Linear default : false
+groundSpeedScalar = 150     # Linear default : 170
+groundSpeedCap = 3.0        # Linear default : 0.4
 
 # Flight is extremely versatile, so its capped at 2. Also, speed 1 is 
 # available relatively early for exploration, but speed 2 will require
 # a time investment in a speed 350 bird.
 # Flight speed 1 @ 150 spd
 # Flight speed 2 @ 350 spd
-flightCappedSpeed = true
-flightUseLogScaling = true
-flightSpeedScalar = 300.0
-flightSpeedCap = 2.0
+flightCappedSpeed = true    # Linear default : true 
+flightUseLogScaling = true  # Linear default : false 
+flightSpeedScalar = 300.0   # Linear default : 64.0
+flightSpeedCap = 2.0        # Linear default : 3.0
 
 # Simming is the most niche ability, so it's uncapped and scales the hardest.
 # Swim speed 1 @ 40 spd
 # Swim speed 2 @ 90 spd
 # Swim speed 3 @ 170 spd 
 # Swim speed 4 @ 300 spd 
-swimCappedSpeed = false
-swimUseLogScaling = true
-swimSpeedScalar = 75.0
-swimSpeedCap = 4.0
+swimCappedSpeed = false     # Linear default : true
+swimUseLogScaling = true    # Linear default : false
+swimSpeedScalar = 75.0      # Linear default : 64.0
+swimSpeedCap = 4.0          # Linear default : 3.0
 
 # Legendaries get a speed boost accounted for in the formula.
 # You may chose to let it bypass the speed caps.
 legendaryModifier = 0.5
 legendaryModifierCapBreak = true
-#
-allowFlying = true
-allowSwimming = true
 
-list = []                # Which Pokemon you can or can't mount.
-alsoFlying = []          # Which Pokemons can fly, ignoring its types
-listUse = ""             # Set to "blacklist" or "whitelist" to control the behavior of the below list. If it is an invalid option or blank, the option isn't used.
-
-# Ground speed isn't as versatile as flight, so it scales harder.
-# Ground speed 1 @ 75 spd
-# Ground speed 2 @ 180 spd
-# Ground speed 3 @ 350 spd
-groundCappedSpeed = true
-groundUseLogScaling = true
-groundSpeedScalar = 150
-groundSpeedCap = 3
-
-# Flight is extremely versatile, so its capped at 2. Also, speed 1 is 
-# available relatively early for exploration, but speed 2 will require
-# a time investment in a speed 350 bird.
-# Flight speed 1 @ 150 spd
-# Flight speed 2 @ 350 spd
-flightCappedSpeed = true
-flightUseLogScaling = true
-flightSpeedScalar = 300.0
-flightSpeedCap = 2.0
-
-# Simming is the most niche ability, so it's uncapped and scales the hardest.
-# Swim speed 1 @ 40 spd
-# Swim speed 2 @ 90 spd
-# Swim speed 3 @ 170 spd 
-# Swim speed 4 @ 300 spd 
-swimCappedSpeed = false
-swimUseLogScaling = true
-swimSpeedScalar = 75.0
-swimSpeedCap = 4.0
-
-# Legendaries get a speed boost accounted for in the formula.
-# You may chose to let it bypass the speed caps.
-legendaryModifier = 0.5
-legendaryModifierCapBreak = true
-#
+# Flying config
 allowFlying = true
 allowSwimming = true
 

--- a/src/main/resources/cobblemounts.toml
+++ b/src/main/resources/cobblemounts.toml
@@ -13,33 +13,33 @@
 # the two modes of scaling for my math nerds : https://www.desmos.com/calculator/ccxdf7ll24
 
 # Ground speed isn't as versatile as flight, so it scales harder.
-# Ground speed 1 @ 75 spd
-# Ground speed 2 @ 180 spd
-# Ground speed 3 @ 350 spd
+# Ground speed .5 @ 100 spd
+# Ground speed 1 @ 250 spd
+# Ground speed 2 @ 600 spd
 groundCappedSpeed = true    # Linear default : true
-groundUseLogScaling = true  # Linear default : false
-groundSpeedScalar = 150.0   # Linear default : 170
-groundSpeedCap = 3.0        # Linear default : 0.4
+groundUseLogScaling = false # Linear default : false
+groundSpeedScalar = 0.75   # Linear default : 170
+groundSpeedCap = 2.0        # Linear default : 0.4
 
 # Flight is extremely versatile, so its capped at 2. Also, speed 1 is 
 # available relatively early for exploration, but speed 2 will require
 # a time investment in a speed 350 bird.
-# Flight speed 1 @ 150 spd
-# Flight speed 2 @ 350 spd
+# Flight speed 0.5 @ 100 spd
+# Flight speed 1 @ 200 spd
+# Flight speed 1.5 @ 350 spd
 flightCappedSpeed = true    # Linear default : true 
 flightUseLogScaling = true  # Linear default : false 
-flightSpeedScalar = 300.0   # Linear default : 64.0
-flightSpeedCap = 2.0        # Linear default : 3.0
+flightSpeedScalar = 450.0   # Linear default : 64.0
+flightSpeedCap = 1.75        # Linear default : 3.0
 
-# Simming is the most niche ability, so it's uncapped and scales the hardest.
-# Swim speed 1 @ 40 spd
-# Swim speed 2 @ 90 spd
-# Swim speed 3 @ 170 spd 
-# Swim speed 4 @ 300 spd 
+# Swimming is the most niche ability, so it's uncapped and scales the hardest.
+# Swim speed 1 @ 70 spd
+# Swim speed 2 @ 200 spd
+# Swim speed 3 @ 350 spd 
 swimCappedSpeed = false     # Linear default : true
 swimUseLogScaling = true    # Linear default : false
-swimSpeedScalar = 75.0      # Linear default : 64.0
-swimSpeedCap = 4.0          # Linear default : 3.0
+swimSpeedScalar = 300.0     # Linear default : 64.0
+swimSpeedCap = 3.0          # Linear default : 3.0
 
 # Legendaries get a speed boost accounted for in the formula.
 # You may chose to let it bypass the speed caps.


### PR DESCRIPTION
Hey ! It's me from discord. Again, this code is VERY messy and the log scaling is IMO just plain bad. However, the fundamentals are there, it's just adding more configs being read.

This fork pretty much just features the ability to adjust not just the speed cap, but  the actual scaling of the mount speed based on the cobblemon's speed stat. The old formula was completely changed, and a new option to use a logarithmic scaling instead is available. These options are all available independently per transport medium (air, water, ground). Also, the legendary bonus has been reworked to be a flat bonus, and there's an option for the legendary speed bonus to break the cap. 

Linear scaling formula : (speed / 256) * (scalar / 2) + (legendarybonus * scalar) / 2

Logarithmic scaling formula : (log((speed + scalar) / scalar) + legendarybonus

Desmos link for these formulae : https://www.desmos.com/calculator/ccxdf7ll24