### PR TITLE
Fix GoalSelector crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx48G
+org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Fabric Properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.1
 loader_version=0.14.22
 
 # Mod Properties
-mod_version=1.2.1
+mod_version=1.2.2
 maven_group=net.ioixd
 archives_base_name=cobblemounts
 

--- a/src/main/java/net/ioixd/Cobblemounts.java
+++ b/src/main/java/net/ioixd/Cobblemounts.java
@@ -6,7 +6,8 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.item.Item;
+import net.minecraft.entity.ai.goal.EatGrassGoal;
+import net.minecraft.entity.ai.goal.WanderAroundGoal;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
@@ -65,12 +66,9 @@ public class Cobblemounts implements ModInitializer {
 							}
 
 						}
-						Item item = player.getMainHandStack().getItem();
-						if (!item.getTranslationKey().contains("item.cobblemon")) {
+						if (player.getMainHandStack().isEmpty()) {
 							player.startRiding(entity, false);
-							pkmnEntity.clearGoalsAndTasks();
 						}
-
 					}
 				}
 			}


### PR DESCRIPTION
Fixes crash caused by removing all goals - [See crash report here.](https://pastebin.com/YkKb9xhd)

Removing goals is redundant as Minecraft handles goals not being run while the entity has a passenger (Example: `WanderAroundGoal#canStart()`)

I also changed it so the player must have an empty hand, as pokemon can hold more than just cobblemon items.

I also bumped version and changed the gradle from 48GB to 2GB because that absolutely demolished my 16GB RAM PC and is not needed lmao