### PR TITLE
[Chore] Instant Dismount on Recall (+ remove unused imports)

### DIFF
--- a/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonMovementHandler.java
@@ -6,11 +6,9 @@ import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
 import com.cobblemon.mod.common.pokemon.Pokemon;
 
 import net.ioixd.client.CobblemountsClient;
-import net.ioixd.MountIsMoving;
 import net.minecraft.block.*;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.*;
-import net.minecraft.entity.passive.TameableShoulderEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
@@ -18,10 +16,6 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
+++ b/src/main/java/net/ioixd/client/mixin/PokemonUpdateTick.java
@@ -1,12 +1,9 @@
 package net.ioixd.client.mixin;
 
-import com.cobblemon.mod.common.entity.pokemon.PokemonBehaviourFlag;
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
 import com.cobblemon.mod.common.pokemon.Pokemon;
-import net.ioixd.Cobblemounts;
 import net.ioixd.client.CobblemountsClient;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.Vec3d;

--- a/src/main/java/net/ioixd/mixin/PokemonMixin.java
+++ b/src/main/java/net/ioixd/mixin/PokemonMixin.java
@@ -1,14 +1,27 @@
 package net.ioixd.mixin;
 
+import java.util.concurrent.CompletableFuture;
+
 import com.cobblemon.mod.common.entity.pokemon.PokemonEntity;
+import com.cobblemon.mod.common.pokemon.Pokemon;
 import net.ioixd.MountIsMoving;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.mob.MobEntity;
+import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PokemonEntity.class)
-public class PokemonMixin implements MountIsMoving {
+public abstract class PokemonMixin extends MobEntity implements MountIsMoving {
     @Unique
     private boolean mount_moving;
+
+    protected PokemonMixin(EntityType<? extends MobEntity> entityType, World world) {
+        super(entityType, world);
+    }
 
     @Override
     public boolean mount_isMoving() {
@@ -18,5 +31,12 @@ public class PokemonMixin implements MountIsMoving {
     @Override
     public void mount_setMoving(boolean b) {
         mount_moving = b;
+    }
+
+    @Inject(method = "recallWithAnimation", at = @At("HEAD"), remap = false)
+    public void recall(CallbackInfoReturnable<CompletableFuture<Pokemon>> cir) {
+        if (getControllingPassenger() != null) {
+            getControllingPassenger().stopRiding();
+        }
     }
 }

--- a/src/main/java/net/ioixd/mixin/PokemonServersideTickMixin.java
+++ b/src/main/java/net/ioixd/mixin/PokemonServersideTickMixin.java
@@ -10,17 +10,13 @@ import net.minecraft.block.FluidBlock;
 import net.minecraft.entity.EntityPose;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.MovementType;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Optional;
 
 /*
 serverside logic here

--- a/src/main/java/net/ioixd/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/net/ioixd/mixin/ServerPlayNetworkHandlerMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.Constant;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ServerPlayNetworkHandler.class)


### PR DESCRIPTION
Title says it all really, at the moment when you recall a pokemon that you're actively riding currently you only dismount it once it's fully in the ball, which is... odd, to say the least. There is a similar issue where you can mount the pokemon before it's fully been called out of the pokeball but that's its own issue.

This PR just makes it so when you begin recalling a pokemon you immediately dismount it.
I also just removed unused imports from various files cause why not :P